### PR TITLE
Update e2e dependencies and optimize CI workers

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,25 +9,25 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dotenvx/dotenvx": "1.47.3",
-        "otpauth": "9.4.0"
+        "@dotenvx/dotenvx": "1.52.0",
+        "otpauth": "9.5.0"
       },
       "devDependencies": {
-        "@playwright/test": "1.53.2",
-        "@types/node": "24.0.10"
+        "@playwright/test": "1.57.0",
+        "@types/node": "25.1.0"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {
-      "version": "1.47.3",
-      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.47.3.tgz",
-      "integrity": "sha512-V0jxoEgyTrP6INJYBXxR6qkaS1qUXmrWTz7FZVx706TgXnMnR7LVRi5Bf9z/o0UmZlkavJD13PLediPi4QvUTQ==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.52.0.tgz",
+      "integrity": "sha512-CaQcc8JvtzQhUSm9877b6V4Tb7HCotkcyud9X2YwdqtQKwgljkMRwU96fVYKnzN3V0Hj74oP7Es+vZ0mS+Aa1w==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^11.1.0",
-        "dotenv": "^16.4.5",
+        "dotenv": "^17.2.1",
         "eciesjs": "^0.4.10",
         "execa": "^5.1.1",
         "fdir": "^6.2.0",
@@ -97,25 +97,25 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
       "license": "MIT",
       "engines": {
-        "node": "^14.21.3 || >=16"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.53.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.2.tgz",
-      "integrity": "sha512-tEB2U5z74ebBeyfGNZ3Jfg29AnW+5HlWhvHtb/Mqco9pFdZU1ZLNdVb2UtB5CvmiilNr2ZfVH/qMmAROG/XTzw==",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.53.2"
+        "playwright": "1.57.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -125,13 +125,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
-      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
+      "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/commander": {
@@ -179,9 +179,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.2.4",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.4.tgz",
+      "integrity": "sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -374,12 +374,12 @@
       }
     },
     "node_modules/otpauth": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.4.0.tgz",
-      "integrity": "sha512-fHIfzIG5RqCkK9cmV8WU+dPQr9/ebR5QOwGZn2JAr1RQF+lmAuLL2YdtdqvmBjNmgJlYk3KZ4a0XokaEhg1Jsw==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.5.0.tgz",
+      "integrity": "sha512-Ldhc6UYl4baR5toGr8nfKC+L/b8/RgHKoIixAebgoNGzUUCET02g04rMEZ2ZsPfeVQhMHcuaOgb28nwMr81zCA==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "2.0.1"
       },
       "funding": {
         "url": "https://github.com/hectorm/otpauth?sponsor=1"
@@ -407,13 +407,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.53.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.2.tgz",
-      "integrity": "sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A==",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.53.2"
+        "playwright-core": "1.57.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -426,9 +426,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.53.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.2.tgz",
-      "integrity": "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -475,9 +475,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -14,11 +14,11 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@dotenvx/dotenvx": "1.47.3",
-    "otpauth": "9.4.0"
+    "@dotenvx/dotenvx": "1.52.0",
+    "otpauth": "9.5.0"
   },
   "devDependencies": {
-    "@playwright/test": "1.53.2",
-    "@types/node": "24.0.10"
+    "@playwright/test": "1.57.0",
+    "@types/node": "25.1.0"
   }
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
   fullyParallel: false, // for more controlled test execution
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 1, // Allow 1 retry locally for better reliability
-  workers: process.env.CI ? 1 : 4,
   timeout: process.env.CI ? 60 * 1000 : 45 * 1000, // Enhanced timeout hierarchy
   expect: {
     timeout: process.env.CI ? 10 * 1000 : 8 * 1000, // for assertions


### PR DESCRIPTION
Updates e2e dependencies and optimizes Playwright CI configuration:

- Update package dependencies to latest versions
- Remove hardcoded `workers: 1` in CI, letting Playwright use its default (50% of available CPUs) for faster test runs